### PR TITLE
Trying to fix issue #9

### DIFF
--- a/tagulous/models/managers.py
+++ b/tagulous/models/managers.py
@@ -253,8 +253,8 @@ class BaseTagRelatedManager(object):
             return item_str in [tag.name for tag in self.tags]
         return item_str in [tag.name.lower() for tag in self.tags]
     
-    def __len__(self):
-        return len(self.tags)
+    # def __len__(self):  # Does our manager need this Operator Overloading?
+    #     return len(self.tags)
 
     def __eq__(self, other):
         """

--- a/tagulous/models/managers.py
+++ b/tagulous/models/managers.py
@@ -253,9 +253,6 @@ class BaseTagRelatedManager(object):
             return item_str in [tag.name for tag in self.tags]
         return item_str in [tag.name.lower() for tag in self.tags]
     
-    # def __len__(self):  # Does our manager need this Operator Overloading?
-    #     return len(self.tags)
-
     def __eq__(self, other):
         """
         Compare a tag string or iterable of tags to the tags on this manager

--- a/tests/test_models_tagfield.py
+++ b/tests/test_models_tagfield.py
@@ -413,9 +413,9 @@ class ModelTagFieldTest(TagTestManager, TestCase):
         self.assertFalse(green in t1.tags, 'green incorrectly found')
     
     def test_len(self):
-        "Check __len__ returns the number of tags"
+        "Check manager count method returns the number of tags"
         t1 = self.create(test_models.TagFieldModel, name="1", tags='blue, red')
-        self.assertEqual(len(t1.tags), 2)
+        self.assertEqual(t1.tags.count(), 2)
     
     def test_eq(self):
         "Check __eq__ correctly determines equality"


### PR DESCRIPTION
Hi Richard,

This is my attempt to fix the issue reported by me almost a month ago, the problem was the `__len__` method overloading. I know the reason to have that method overloaded, unfortunately that is causing tastypie don't work with tagulous, also by inspecting the source code, I cannot find one occurrence where the **len** method is used. Perhaps, if we need a method to count the tags, we should use:  TheModel.objects.count()

Hoping this change doesn't cause any conflict.
