### PR TITLE
Add through attribute to TagDescriptor

### DIFF
--- a/tagulous/models/descriptors.py
+++ b/tagulous/models/descriptors.py
@@ -299,3 +299,7 @@ class TagDescriptor(BaseTagDescriptor):
         else:
             # Unknown
             raise ValueError('Unexpected value assigned to TagField')
+
+    @property
+    def through(self):
+        return self.descriptor.through


### PR DESCRIPTION
The regular `ManyToManyDescriptor` from Django provides the attribute `through` and some apps like https://github.com/makinacorpus/django-tracking-fields use it. The pull request adds this attribute to `TagDescriptor` to mimic `ManyToManyDescriptor`.
