### PR TITLE
Fixed DoesNotExist exeption in case of different databases for read and write

### DIFF
--- a/tagulous/models/models.py
+++ b/tagulous/models/models.py
@@ -334,8 +334,8 @@ class BaseTagModel(with_metaclass(TagModelBase, models.Model)):
         )
 
         # Reload count
-        # Use BD for write because we just updated the value
-        using = router.db_for_write(self.__class__, instance=self)
+        # Use DB for write because we just updated the value
+        using = router.db_for_write(self.tag_model, instance=self)
         if hasattr(self, 'refresh_from_db'):
             self.refresh_from_db(using=using)
         else:

--- a/tagulous/models/models.py
+++ b/tagulous/models/models.py
@@ -334,11 +334,13 @@ class BaseTagModel(with_metaclass(TagModelBase, models.Model)):
         )
 
         # Reload count
+        # Use BD for write because we just updated the value
+        using = router.db_for_write(self.__class__, instance=self)
         if hasattr(self, 'refresh_from_db'):
-            self.refresh_from_db()
+            self.refresh_from_db(using=using)
         else:
             # Django 1.7 or earlier
-            self.count = self.__class__.objects.get(pk=self.pk).count
+            self.count = self.__class__.objects.using(using).get(pk=self.pk).count
 
         self.try_delete()
 


### PR DESCRIPTION
I have find an issue with django-tagulous in case of multiple database configuration.
Here is my database configuration:
    DATABASES = {
        'default': { # Master DB for read and write
            "ENGINE": "django.contrib.gis.db.backends.postgis",
            "USER": "some_user",
            "NAME": "some_db",
            "PASSWORD": "*****",
            "HOST": "host",
            "PORT": "5432"
        },
        'reader': { # Readonly Slave DB
            "ENGINE": "django.contrib.gis.db.backends.postgis",
            "USER": "some_user",
            "NAME": "some_db",
            "PASSWORD": "*****",
            "HOST": "host",
            "PORT": "5432"
        },
    }

With this configuration i got en exeption: Tagulous_<Model>_<field> matching query does not exist.
I think this is because Django admin tries to cover all queries into single transaction so until it will be closed the slave DB will not be updated with new data.
So when we just updated the tag counter we should use the same DB to refresh tag instance.




