### PR TITLE
Fixing single character tags

### DIFF
--- a/tagulous/utils.py
+++ b/tagulous/utils.py
@@ -256,38 +256,13 @@ def split_tree_name(name):
 
     A slash can be escaped by double slash, ie //
     """
-    parts = []
-    split = False
-    start = 0
-    index = 0
-    chars = list(enumerate(name))
-    while chars:
-        index, char = chars.pop(0)
-        if char == TREE:
-            if split:
-                # Slash was escaped
-                split = False
-            else:
-                split = True
+    name = name.strip()
+    if len(name) == 0:
+        return []
 
-        elif split:
-            # Previous character was a valid delimiter
-            parts.append(name[start:index - 1].strip())
-            start = index
-            split = False
-
-    if split:
-        # Trailing slash - shouldn't happen if sanitised, but handle anyway
-        parts += [name[start:index].strip(), '']
-
-    elif start < index:
-        # If string not empty, add everything after last slash
-        parts.append(name[start:].strip())
-
-    return [
-        part.replace(TREE + TREE, TREE) for part in parts
-    ]
-
+    ESCAPE_CHAR = '\0'
+    return [ x.strip().replace(ESCAPE_CHAR, TREE)
+             for x in name.replace(TREE+TREE, ESCAPE_CHAR).split(TREE)]
 
 def join_tree_name(parts):
     """

--- a/tests/test_models_tree.py
+++ b/tests/test_models_tree.py
@@ -90,6 +90,13 @@ class TagTreeModelTest(TagTreeTestManager, TestCase):
             t1, name='One', label='One', slug='one', path='one', level=1,
         )
 
+    def test_level_1_single_character(self):
+        "Check level 1 node created correctly if only one character"
+        t1 = self.tag_model.objects.create(name='O')
+        self.assertTreeTag(
+            t1, name='O', label='O', slug='o', path='o', level=1,
+        )
+
     def test_level_2_existing_l1(self):
         "Check level 2 node created with existing level 1"
         t1 = self.tag_model.objects.create(name='One')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -275,12 +275,24 @@ class TagTreeSplitUtilTest(TestCase):
         self.assertEqual(len(parts), 1)
         self.assertEqual(parts[0], "one")
 
+    def test_split_tree_one_single_character(self):
+        parts = tag_utils.split_tree_name("o")
+        self.assertEqual(len(parts), 1)
+        self.assertEqual(parts[0], "o")
+
     def test_split_tree_three(self):
         parts = tag_utils.split_tree_name("one/two/three")
         self.assertEqual(len(parts), 3)
         self.assertEqual(parts[0], "one")
         self.assertEqual(parts[1], "two")
         self.assertEqual(parts[2], "three")
+
+    def test_split_tree_three_last_one_with_single_character(self):
+        parts = tag_utils.split_tree_name("one/two/3")
+        self.assertEqual(len(parts), 3)
+        self.assertEqual(parts[0], "one")
+        self.assertEqual(parts[1], "two")
+        self.assertEqual(parts[2], "3")
 
     def test_split_tree_three_spaced(self):
         parts = tag_utils.split_tree_name("  one  /  two  /  three  ")


### PR DESCRIPTION
I've just opened issue #81, because I cannot use single character tags with the current version
of tagulous. Here is a pull request which might fix the issue.

First I've added some tests to show the problems I have. Second, I've replaced the function
`utils.split_tree_name(name)` with simpler code. 

Do I miss something or can it just be implemented by using the `split()` method of strings, as I did?
One drawback of my solution is that you cannot use a NULL character in tags anymore,
but that shouldn't be problem - although there also would be a solution for that. 

What do you think? The tests are passing, also the new ones I've added.