### PR TITLE
update settingsin docs to reflect select2 v4

### DIFF
--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -134,13 +134,13 @@ path under ``STATIC_URL`` to the appropriate ``TAGULOUS_`` settings.
 
 Tagulous includes the following adaptors:
 
-Select2 (version 3)
+Select2 (version 4)
 -------------------
 
 The default adaptor, for `Select2 <https://select2.github.io/>`_.
 
 Path:
-    ``tagulous/adaptor/select2-3.js``
+    ``tagulous/adaptor/select2-4.js``
 
 Autocomplete settings should be a dict:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -148,10 +148,10 @@ Settings
     Default::
 
         TAGULOUS_AUTOCOMPLETE_JS = (
-            'tagulous/lib/jquery.js',
-            'tagulous/lib/select2-3/select2.min.js',
-            'tagulous/tagulous.js',
-            'tagulous/adaptor/select2.js',
+            "tagulous/lib/jquery.js",
+            "tagulous/lib/select2-4/js/select2.full.min.js",
+            "tagulous/tagulous.js",
+            "tagulous/adaptor/select2-4.js",
         )
 
 ``TAGULOUS_AUTOCOMPLETE_CSS``
@@ -164,7 +164,7 @@ Settings
     Default::
 
         TAGULOUS_AUTOCOMPLETE_CSS = {
-            'all': ['tagulous/lib/select2-3/select2.css']
+            'all': ['tagulous/lib/select2-4/css/select2.min.css']
         }
 
 ``TAGULOUS_AUTOCOMPLETE_SETTINGS``


### PR DESCRIPTION
I wasn't sure if it should go against `dev` or `master`. I chose master so in theory it could go straight to the current live docs?