### PR TITLE
Add TagOpeions autocomplete_view_args and autocomplete_view_kwargs

### DIFF
--- a/docs/tag_options.rst
+++ b/docs/tag_options.rst
@@ -184,6 +184,25 @@ If this is an invalid view, a ``ValueError`` will be raised.
 Default: ``None``
 
 
+.. _option_autocomplete_view_args:
+
+``autocomplete_view_args``
+--------------------------
+Optional ``args`` passed to the ``autocomplete_view``.
+
+Default: ``None``
+
+
+.. _option_autocomplete_view_kwargs:
+
+``autocomplete_view_kwargs``
+--------------------------
+Optional ``kwargs`` passed to the ``autocomplete_view``.
+
+Default: ``None``
+
+
+
 .. _option_autocomplete_limit:
 
 ``autocomplete_limit``

--- a/tagulous/constants.py
+++ b/tagulous/constants.py
@@ -23,6 +23,8 @@ OPTION_DEFAULTS = {
     "tree": False,
     "autocomplete_initial": False,
     "autocomplete_view": "",
+    "autocomplete_view_args": None,
+    "autocomplete_view_kwargs": None,
     "autocomplete_limit": 100,
     "autocomplete_settings": None,
     "get_absolute_url": None,

--- a/tagulous/forms.py
+++ b/tagulous/forms.py
@@ -32,19 +32,13 @@ class TagWidgetBase(forms.TextInput):
     choices = None
 
     def render(self, name, value, attrs={}, renderer=None):
-
-        # Merge default autocomplete settings into tag options
-        tag_options = self.tag_options.form_items(with_defaults=False)
-        if self.default_autocomplete_settings is not None:
-            autocomplete_settings = self.default_autocomplete_settings.copy()
-            autocomplete_settings.update(tag_options.get("autocomplete_settings", {}))
-            tag_options["autocomplete_settings"] = autocomplete_settings
-
         # Try to provide a URL for the autocomplete to load tags on demand
         autocomplete_view = self.tag_options.autocomplete_view
         if autocomplete_view:
             try:
-                attrs["data-tag-url"] = reverse(autocomplete_view, kwargs={} if autocomplete_settings is None else autocomplete_settings)
+                attrs["data-tag-url"] = reverse(autocomplete_view,
+                    args=self.tag_options.autocomplete_view_args,
+                    kwargs=self.tag_options.autocomplete_view_kwargs)
             except NoReverseMatch as e:
                 raise ValueError("Invalid autocomplete view: %s" % e)
 
@@ -67,6 +61,12 @@ class TagWidgetBase(forms.TextInput):
                 )
             )
 
+        # Merge default autocomplete settings into tag options
+        tag_options = self.tag_options.form_items(with_defaults=False)
+        if self.default_autocomplete_settings is not None:
+            autocomplete_settings = self.default_autocomplete_settings.copy()
+            autocomplete_settings.update(tag_options.get("autocomplete_settings", {}))
+            tag_options["autocomplete_settings"] = autocomplete_settings
 
         # Inject extra settings
         tag_options.update({"required": self.is_required})


### PR DESCRIPTION
This PR adds options `autocomplete_view_args` and `autocomplete_view_kwargs` and `TagOptions`, and use them in to obtain url for `autocomplete_view`. it allows more flexibility in the determination for `autocomplete_view`. See #119 for a use case of this feature.