### PR TITLE
Add info in the docs for rendering form in custom templates

### DIFF
--- a/docs/views.rst
+++ b/docs/views.rst
@@ -44,6 +44,24 @@ These views look for two GET parameters:
 
 For an example, see the :ref:`example_autocomplete_views` example.
 
+.. _Custom_views:
+
+Custom views
+============
+
+To render the form outside of the admin, you must include links to the 
+tagulous .js and .css files. The easiest way to do this is to add links
+to the media files inside the template itself like so:
+
+{% block content %}
+
+{{ form.media.css }}
+{{ form.media.js }}
+{{ form }}
+
+{% endblock %}
+
+Otherwise you can link to the files directly in the <head> section.
 
 .. _tag_clouds:
 

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -53,13 +53,13 @@ To render the form outside of the admin, you must include links to the
 tagulous .js and .css files. The easiest way to do this is to add links
 to the media files inside the template itself like so:
 
-{% block content %}
+`{% block content %}
 
 {{ form.media.css }}
 {{ form.media.js }}
 {{ form }}
 
-{% endblock %}
+{% endblock %}`
 
 Otherwise you can link to the files directly in the <head> section.
 


### PR DESCRIPTION
Not having this info made trouble shooting why the the tags form was not rendering very difficult. This should close issue #57 and other related issues.