### PR TITLE
Update docs to explain how to render form

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,7 +31,12 @@ Instructions
    There are other global :ref:`settings` you can add here.
 
 
-3. Add Tagulous fields to your project - see :doc:`models/index`, :doc:`forms` and
+3. Run ``collectstatic``::
+
+    python manage.py collectstatic
+
+
+4. Add Tagulous fields to your project - see :doc:`models/index`, :doc:`forms` and
    :doc:`usage`.
 
 When you want to upgrade your Tagulous installation in the future, check

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -51,15 +51,14 @@ Custom views
 
 To render the form outside of the admin, you must include links to the 
 tagulous .js and .css files. The easiest way to do this is to add links
-to the media files inside the template itself like so:
+to the media files inside the template itself like so::
 
-`{% block content %}
+    {% block content %}
 
-{{ form.media.css }}
-{{ form.media.js }}
-{{ form }}
+    {{ form.media }}
+    {{ form }}
 
-{% endblock %}`
+    {% endblock %}
 
 Otherwise you can link to the files directly in the <head> section.
 

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -44,6 +44,24 @@ These views look for two GET parameters:
 
 For an example, see the :ref:`example_autocomplete_views` example.
 
+.. _Custom_views:
+
+Custom views
+============
+
+To render the form outside of the admin, you must include links to the 
+tagulous .js and .css files. The easiest way to do this is to add links
+to the media files inside the template itself like so:
+
+{% block content %}
+
+{{ form.media.css }}
+{{ form.media.js }}
+{{ form }}
+
+{% endblock %}
+
+Otherwise you can link to the files directly in the <head> section.
 
 .. _tag_clouds:
 

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -53,13 +53,13 @@ To render the form outside of the admin, you must include links to the
 tagulous .js and .css files. The easiest way to do this is to add links
 to the media files inside the template itself like so:
 
-{% block content %}
+`{% block content %}
 
 {{ form.media.css }}
 {{ form.media.js }}
 {{ form }}
 
-{% endblock %}
+{% endblock %}`
 
 Otherwise you can link to the files directly in the <head> section.
 

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -50,8 +50,8 @@ Custom views
 ============
 
 To render the form outside of the admin, you must include links to the 
-tagulous .js and .css files. The easiest way to do this is to add links
-to the media files inside the template itself like so::
+tagulous .js and .css files in the template. The easiest way to do this 
+is to add links to the media files inside the template itself like so::
 
     {% block content %}
 


### PR DESCRIPTION
I had lots of trouble getting the form to render properly. It wasn't documented clearly that I needed to add `{{ form.media }}` to the template and that I needed to run `python manage.py collectstatic `so that the the tagulous files could be accessed.

This addresses issue #57 and related issues.