### PR TITLE
Fixes #144 by inspecting args, kwargs

### DIFF
--- a/tagulous/models/tagged.py
+++ b/tagulous/models/tagged.py
@@ -116,7 +116,10 @@ class TaggedQuerySet(models.query.QuerySet):
         """
         if django.VERSION >= (3, 2):
             # Arguments changed to _filter_or_exclude(self, negate, args, kwargs)
-            args, kwargs = args
+            if len(args) == 2:
+                args, kwargs = args
+            elif set(kwargs.keys()) == {"args", "kwargs"}:
+                args, kwargs = kwargs["args"], kwargs["kwargs"]
 
         # TODO: Replace with custom lookups
         safe_fields, singletag_fields, tag_fields, field_lookup = _split_kwargs(

--- a/tests/test_models_tagged.py
+++ b/tests/test_models_tagged.py
@@ -364,6 +364,11 @@ class ModelTaggedQuerysetTest(TagTestManager, TestCase):
     # .filter()
     #
 
+    def test_object_empty_complex_filter(self):
+        "Check that object.complex_filter can be called without arguments"
+        qs1 = self.test_model.objects.complex_filter({})
+        self.assertEqual(qs1.count(), 3)
+
     def test_object_singletag_filter(self):
         "Check that object.filter finds the correct items by singletag"
         qs1 = self.test_model.objects.filter(singletag="Mr")


### PR DESCRIPTION
This broke admin autocomplete for us when the tags are in the search_fields of the tagged model. Added a simple test.