### PR TITLE
Fix media from AutocompleteMixin

### DIFF
--- a/tagulous/forms.py
+++ b/tagulous/forms.py
@@ -1,13 +1,13 @@
 import json
 
 from django import forms
-from django.contrib.admin.widgets import AutocompleteMixin
+from django.contrib.admin.widgets import AutocompleteMixin, SELECT2_TRANSLATIONS
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models.query import QuerySet
 from django.urls import NoReverseMatch, reverse
 from django.utils.encoding import force_str
 from django.utils.html import escape
-from django.utils.translation import gettext as _
+from django.utils.translation import get_language, gettext as _
 
 from . import settings
 from .models import options
@@ -118,7 +118,10 @@ class AdminTagWidget(TagWidgetBase):
     def media(self):
         # Get the media from the AutocompleteMixin - this will give us Django's
         # vendored jQuery and select2
-        media = AutocompleteMixin.media.fget(None)
+        class GetMedia(AutocompleteMixin):
+            def __init__(self):
+                self.i18_name = SELECT2_TRANSLATIONS.get(get_language())
+        media = GetMedia().media
 
         return media + forms.Media(
             js=settings.ADMIN_AUTOCOMPLETE_JS,


### PR DESCRIPTION
https://github.com/django/django/pull/14871

Django 4.0.x introduced that made it no longer possible to retrieve the media property by simply calling `fget(None)`.  Instead, we now must mock out an object containing the `i18_name` attribute.