### PR TITLE
Allow user-defined display function in enhance

### DIFF
--- a/tagulous/admin.py
+++ b/tagulous/admin.py
@@ -177,7 +177,7 @@ def _create_display(field):
     return display
 
 
-def enhance(model, admin_class):
+def enhance(model, admin_class, display_func=_create_display):
     """
     Add tag support to the admin class based on the specified model
     """
@@ -231,7 +231,7 @@ def enhance(model, admin_class):
                     admin_class.list_display[i] = display_name
 
                     # Add display function to admin class
-                    setattr(admin_class, display_name, _create_display(field))
+                    setattr(admin_class, display_name, display_func(field))
 
     #
     # If admin is for a tag model, ensure any inlines for tagged models are


### PR DESCRIPTION
Allow user provided display function, so that we can do something like this:

```
from django.urls import reverse
from django.utils.html import format_html_join
from tagulous.constants import COMMA, DOUBLE_QUOTE, QUOTE, SPACE


def _my_create_display(field_name):
    def display(self, obj):
        field = getattr(obj, field_name)
        names = []
        for tag in field.tags:
            name = str(tag)
            name = name.replace(QUOTE, DOUBLE_QUOTE)
            if COMMA in name or SPACE in name:
                names.append("%s" % name)
            else:
                names.append(name)
        return format_html_join(
            ", ",
            '<a href="{}">{}</a>',
            (
                (reverse("admin:%s_%s_change" % (
                    field.model._meta.app_label,
                    field.tag_model.__name__.lower()
                ), args=(tag.id,)), name)
                for name, tag in zip(names, field.tags)
            )
        )
    display.short_description = field_name.replace("_", " ")
    return display


class MyModel(models.Model):
    tags = tagulous.models.TagField(blank=True)


class MyAdmin(tagulous.admin.TaggedModelAdmin):
    list_display = ['tags']
tagulous.admin.enhance(MyModel, MyAdmin, display_func=_my_create_display)
admin.site.register(MyModel, MyAdmin)
```

This produces a nice list of tags in the list_display, where each tag links to the change view of that specific tag in the admin:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/766820/153955529-7a71a422-7793-4112-865f-8c52fb95b6f2.png">
