### PR TITLE
Remove Django 4.1 warning

### DIFF
--- a/tagulous/__init__.py
+++ b/tagulous/__init__.py
@@ -5,5 +5,3 @@ Django Tagulous - Fabulous Tags
 __version__ = "1.3.3"
 __license__ = "BSD"
 __author__ = "Richard Terry"
-
-default_app_config = "tagulous.apps.TagulousConfig"


### PR DESCRIPTION
e.g.: https://github.com/radiac/django-tagulous/runs/7107977655?check_suite_focus=true#step:5:20
```
../../../../../opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/apps/registry.py:91
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/apps/registry.py:91:
RemovedInDjango41Warning: 'tagulous' defines default_app_config = 'tagulous.apps.TagulousConfig'.
Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)
```
