### PR TITLE
feature: allow_create TagOption

### DIFF
--- a/docs/tag_options.rst
+++ b/docs/tag_options.rst
@@ -306,6 +306,16 @@ name from its ``verbose_name`` argument, falling back to the field name.
     ``verbose_name_singular`` to a string which is 38 characters or less.
 
 
+.. _option_allow_create:
+
+``allow_create``
+--------------------
+Controls whether in a form, users are prompted to create new tags or whether 
+they're restricted to choosing from pre-existing tags.
+
+Default: ``True``
+
+
 .. _form_options:
 
 Form Options
@@ -319,6 +329,7 @@ The following options are used by form fields:
 * :ref:`option_tree`
 * :ref:`option_autocomplete_limit`
 * :ref:`option_autocomplete_settings`
+* :ref:`option_allow_create`
 
 
 .. _tagoptions:

--- a/tagulous/constants.py
+++ b/tagulous/constants.py
@@ -35,6 +35,7 @@ OPTION_DEFAULTS = {
     "get_absolute_url": None,
     "verbose_name_singular": None,
     "verbose_name_plural": None,
+    "allow_create": True,
 }
 
 # List of model TagField options which are relevant to form fields
@@ -46,4 +47,5 @@ FORM_OPTIONS = [
     "tree",
     "autocomplete_limit",
     "autocomplete_settings",
+    "allow_create",
 ]

--- a/tagulous/static/tagulous/adaptor/select2-3.js
+++ b/tagulous/static/tagulous/adaptor/select2-3.js
@@ -181,7 +181,7 @@
         $.extend(args, {
             // Our overriden methods
             tokenizer: tokenizer,
-            createSearchChoice: createSearchChoice,
+            createSearchChoice: options.allow_create !== false ? createSearchChoice : (term, data) => {return null},
 
             // Things defined by field/tag options, which can't be overridden
             multiple: !isSingle,

--- a/tagulous/static/tagulous/adaptor/select2-4.js
+++ b/tagulous/static/tagulous/adaptor/select2-4.js
@@ -165,7 +165,7 @@
         $.extend(args, {
             // Select2 options
             tokenizer: tokenizer,
-            tags: true,
+            tags: !options.allow_create,
 
             // Things defined by field/tag options, which can't be overridden
             multiple: !isSingle,


### PR DESCRIPTION
Closes #7 

Controls whether the front-end component can create a new tag. Doesn't restrict it server-side, which is left to the application developer