### PR TITLE
Disable JS parsing on SingleTagField change

### DIFF
--- a/tagulous/static/tagulous/adaptor/select2-4.js
+++ b/tagulous/static/tagulous/adaptor/select2-4.js
@@ -271,8 +271,12 @@
         $selectEl.on("change", function (e) {
           var valueObjects = $selectEl.select2('data');
           var values = valueObjects.map(function(obj) { return obj.text; });
-          var rendered = Tagulous.renderTags(values);
-          $inputEl.val(rendered);
+          if (isSingle) {
+            $inputEl.val(values[0])
+          } else {
+            var rendered = Tagulous.renderTags(values);
+            $inputEl.val(rendered);
+          }
         });
         return $selectCtl;
     }


### PR DESCRIPTION
Disables all parsing on SingleTagField as proposed in #176.

Personally was having the issue that if for a SingleTagField I had an existing tag titled `Finance/Credit Cards` (no quotes), upon adding this tag to an object it would create the tags `"Finance` (with a quote at the start) and `"Finance/Credit Cards"` (with quotes). This fixes that.

Haven't dug too deep so I'm not sure if there are edge cases I'm not solving for. Going off of @radiac's proposed solution in #176. Also not sure if support for Select2 v3 is still needed. Didn't update the Select2 vs3 adapter.