### PR TITLE
Include static and template directories in the built package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include tagulous/static *
+recursive-include tagulous/templates *


### PR DESCRIPTION
v2.0.0 on PyPI doesn't contain the `static` or `templates` directories.  This change restores the two relevant lines of MANIFEST.in that are [still relevant in a pyproject.toml world when not using a build backend that can read VCS information](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#include-package-data).

While testing this out locally, I noticed that I needed to remove my local `django_tagulous.egg-info` directory to avoid some level of caching.  I could remove the MANIFEST.in I had added and the static and templates directories would still be included unless I removed that directory first.

I know from experience that getting this stuff right consistently is really hard!  I haven't used it myself, but I've heard many people suggest [this workflow](https://github.com/hynek/build-and-inspect-python-package) to help with this type of packaging failure.