### PR TITLE
fix #187 - fix monkeypatch for django 5.2

### DIFF
--- a/tagulous/serializers/base.py
+++ b/tagulous/serializers/base.py
@@ -62,7 +62,10 @@ def monkeypatch_get_model(serializer):
     Given a model identifier, get the model - unless it's a TaggedModel, in
     which case return a temporary fake model to get it serialized.
     """
-    old_get_model = serializer._get_model
+    try:
+        old_get_model = serializer.Deserializer._get_model_from_node
+    except AttributeError:
+        old_get_model = serializer._get_model
 
     def _get_model(model_identifier):
         RealModel = old_get_model(model_identifier)
@@ -74,4 +77,7 @@ def monkeypatch_get_model(serializer):
 
         return Model
 
-    serializer._get_model = _get_model
+    if hasattr(serializer.Deserializer, "_get_model_from_node"):
+        serializer.Deserializer._get_model_from_node = staticmethod(_get_model)
+    else:
+        serializer._get_model = _get_model

--- a/tests/requirements/django-5.2.txt
+++ b/tests/requirements/django-5.2.txt
@@ -1,0 +1,3 @@
+-r base.txt
+
+django==5.2.*


### PR DESCRIPTION
Fixes the monkeypatching issue with django 5.2.
I ran tests for 4.2, 5.0, 5.1 and 5.2, and all pass.