### PR TITLE
Django 5.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
             django: "5.0"
           - python: "3.12"
             django: "5.1"
+          - python: "3.12"
+            django: "5.2"
 
     steps:
       - uses: actions/checkout@v2
@@ -55,6 +57,8 @@ jobs:
             django: "4.2"
           - python: "3.12"
             django: "5.1"
+          - python: "3.12"
+            django: "5.2"
 
     services:
       postgres:
@@ -104,6 +108,8 @@ jobs:
             django: "4.2"
           - python: "3.12"
             django: "5.1"
+          - python: "3.12"
+            django: "5.2"
 
     services:
       mysql:

--- a/tagulous/serializers/base.py
+++ b/tagulous/serializers/base.py
@@ -62,7 +62,18 @@ def monkeypatch_get_model(serializer):
     Given a model identifier, get the model - unless it's a TaggedModel, in
     which case return a temporary fake model to get it serialized.
     """
-    old_get_model = serializer._get_model
+    # Django 5.2+ moved _get_model to Deserializer._get_model_from_node
+    if hasattr(serializer, 'Deserializer') and hasattr(serializer.Deserializer, '_get_model_from_node'):
+        old_get_model = serializer.Deserializer._get_model_from_node
+    elif hasattr(serializer, '_get_model'):
+        old_get_model = serializer._get_model
+    else:
+        # Fallback - try to find any get_model method
+        if hasattr(serializer, 'get_model'):
+            old_get_model = serializer.get_model
+        else:
+            # If we can't find any get_model method, skip monkeypatching
+            return
 
     def _get_model(model_identifier):
         RealModel = old_get_model(model_identifier)
@@ -74,4 +85,10 @@ def monkeypatch_get_model(serializer):
 
         return Model
 
-    serializer._get_model = _get_model
+    # Apply the monkeypatch to the appropriate location
+    if hasattr(serializer, 'Deserializer') and hasattr(serializer.Deserializer, '_get_model_from_node'):
+        serializer.Deserializer._get_model_from_node = staticmethod(_get_model)
+    elif hasattr(serializer, '_get_model'):
+        serializer._get_model = _get_model
+    elif hasattr(serializer, 'get_model'):
+        serializer.get_model = _get_model

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -4,7 +4,7 @@ tox
 pyyaml
 djangorestframework
 
-pytest
+pytest>=8.0.0
 pytest-pythonpath
-pytest-cov
-pytest-django
+pytest-cov>=5.0.0
+pytest-django>=4.8.0

--- a/tests/requirements/django-5.2.txt
+++ b/tests/requirements/django-5.2.txt
@@ -1,0 +1,3 @@
+-r base.txt
+
+django==5.2.8

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -343,3 +343,46 @@ class MixedTestMixin(TagTestManager, TestCase):
         self.assertInstanceEqual(obj, name="test", singletag="test", tags="test")
         self.assertEqual(obj.many_to_one.count(), 1)
         self.assertEqual(obj.many_to_one.first().name, "rfk1")
+
+
+class MonkeypatchTest(TestCase):
+    """
+    Test that the monkeypatch_get_model function works correctly with different Django versions
+    """
+
+    def test_monkeypatch_compatibility(self):
+        """
+        Test that monkeypatch works with both old and new Django serializer APIs
+        """
+        from django.core.serializers import python as python_serializer
+        from tagulous.serializers import base
+
+        # Store original methods to restore later
+        original_get_model = getattr(python_serializer, '_get_model', None)
+        original_deserializer_get_model = None
+
+        if hasattr(python_serializer, 'Deserializer') and hasattr(python_serializer.Deserializer, '_get_model_from_node'):
+            original_deserializer_get_model = python_serializer.Deserializer._get_model_from_node
+
+        try:
+            # Test that monkeypatch doesn't raise AttributeError
+            base.monkeypatch_get_model(python_serializer)
+
+            # Verify that some form of get_model method exists after monkeypatching
+            has_get_model = (
+                hasattr(python_serializer, '_get_model') or
+                (hasattr(python_serializer, 'Deserializer') and
+                 hasattr(python_serializer.Deserializer, '_get_model_from_node')) or
+                hasattr(python_serializer, 'get_model')
+            )
+            self.assertTrue(has_get_model, "Monkeypatch should ensure some get_model method exists")
+
+        finally:
+            # Restore original methods
+            if original_get_model is not None:
+                python_serializer._get_model = original_get_model
+            elif hasattr(python_serializer, '_get_model'):
+                delattr(python_serializer, '_get_model')
+
+            if original_deserializer_get_model is not None:
+                python_serializer.Deserializer._get_model_from_node = original_deserializer_get_model

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{3.12}-django{4.2}
     py{3.12}-django{5.0}
     py{3.12}-django{5.1}
+    py{3.12}-django{5.2}
     report
 
 [testenv]
@@ -30,6 +31,7 @@ deps =
     django4.2: -r tests/requirements/django-4.2.txt
     django5.0: -r tests/requirements/django-5.0.txt
     django5.1: -r tests/requirements/django-5.1.txt
+    django5.2: -r tests/requirements/django-5.2.txt
 
     psycopg2-binary
     mysqlclient


### PR DESCRIPTION
Add support for Django 5.2 including tests and fixing https://github.com/radiac/django-tagulous/issues/187

Based on https://github.com/radiac/django-tagulous/pull/188 but extended a little bit. And I needed a fork owned by myself to be able to continue in Defect Dojo.

All tests are passing on Django 5.1 and 5.2. The monkey patching also works on Pythong 3.13 and 3.14.

```
5.1.14:
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.12.12-final-0 _______________

Name                                           Stmts   Miss  Cover
------------------------------------------------------------------
tagulous/__init__.py                               3      0   100%
tagulous/admin.py                                116      3    97%
tagulous/apps.py                                   8      0   100%
tagulous/checks.py                                12      0   100%
tagulous/constants.py                              9      0   100%
tagulous/contrib/__init__.py                       0      0   100%
tagulous/contrib/drf.py                           21      0   100%
tagulous/forms.py                                151      2    99%
tagulous/management/__init__.py                    0      0   100%
tagulous/management/commands/__init__.py           0      0   100%
tagulous/management/commands/initial_tags.py      27      0   100%
tagulous/models/__init__.py                        9      0   100%
tagulous/models/cast.py                           15      0   100%
tagulous/models/descriptors.py                    82      1    99%
tagulous/models/fields.py                        186      1    99%
tagulous/models/initial.py                        14      0   100%
tagulous/models/managers.py                      286      3    99%
tagulous/models/migrations.py                     45      0   100%
tagulous/models/models.py                        315      1    99%
tagulous/models/options.py                        56      0   100%
tagulous/models/tagged.py                        186      2    99%
tagulous/serializers/__init__.py                   0      0   100%
tagulous/serializers/base.py                      44      7    84%
tagulous/serializers/json.py                       5      0   100%
tagulous/serializers/python.py                     6      0   100%
tagulous/serializers/pyyaml.py                     5      0   100%
tagulous/serializers/xml_serializer.py            39      0   100%
tagulous/settings.py                              23      1    96%
tagulous/signals/__init__.py                       0      0   100%
tagulous/signals/post.py                          54      0   100%
tagulous/signals/pre.py                            8      0   100%
tagulous/utils.py                                109      0   100%
tagulous/views.py                                 33      0   100%
------------------------------------------------------------------
TOTAL                                           1867     21    99%
Coverage HTML written to dir htmlcov
====================== 672 passed, 666 warnings in 17.59s ======================


5.2.8

================================ tests coverage ================================
_______________ coverage: platform linux, python 3.12.11-final-0 _______________

Name                                           Stmts   Miss  Cover
------------------------------------------------------------------
tagulous/__init__.py                               3      0   100%
tagulous/admin.py                                116      3    97%
tagulous/apps.py                                   8      0   100%
tagulous/checks.py                                12      0   100%
tagulous/constants.py                              9      0   100%
tagulous/contrib/__init__.py                       0      0   100%
tagulous/contrib/drf.py                           21      0   100%
tagulous/forms.py                                151      2    99%
tagulous/management/__init__.py                    0      0   100%
tagulous/management/commands/__init__.py           0      0   100%
tagulous/management/commands/initial_tags.py      27      0   100%
tagulous/models/__init__.py                        9      0   100%
tagulous/models/cast.py                           15      0   100%
tagulous/models/descriptors.py                    82      1    99%
tagulous/models/fields.py                        186      1    99%
tagulous/models/initial.py                        14      0   100%
tagulous/models/managers.py                      286      3    99%
tagulous/models/migrations.py                     45      0   100%
tagulous/models/models.py                        315      1    99%
tagulous/models/options.py                        56      0   100%
tagulous/models/tagged.py                        186      2    99%
tagulous/serializers/__init__.py                   0      0   100%
tagulous/serializers/base.py                      44      7    84%
tagulous/serializers/json.py                       5      0   100%
tagulous/serializers/python.py                     6      0   100%
tagulous/serializers/pyyaml.py                     5      0   100%
tagulous/serializers/xml_serializer.py            39      0   100%
tagulous/settings.py                              23      1    96%
tagulous/signals/__init__.py                       0      0   100%
tagulous/signals/post.py                          54      0   100%
tagulous/signals/pre.py                            8      0   100%
tagulous/utils.py                                109      0   100%
tagulous/views.py                                 33      0   100%
------------------------------------------------------------------
TOTAL                                           1867     21    99%
Coverage HTML written to dir htmlcov
====================== 672 passed, 666 warnings in 17.84s ======================

```